### PR TITLE
User experience improvement in GenericAnnotationWidget

### DIFF
--- a/ultrack/widgets/_generic_annotation_widget.py
+++ b/ultrack/widgets/_generic_annotation_widget.py
@@ -144,6 +144,8 @@ class GenericAnnotationWidget(GenericDataWidget):
         else:
             self._viewer.dims.set_point(range(4), (node.time, *node.centroid))
 
+        self._viewer.camera.center = node.centroid
+
     def _on_confirm(self, layer: Optional[Labels] = None) -> None:
         if not self._confirm_btn.enabled:
             # required by key binding

--- a/ultrack/widgets/_generic_annotation_widget.py
+++ b/ultrack/widgets/_generic_annotation_widget.py
@@ -105,6 +105,7 @@ class GenericAnnotationWidget(GenericDataWidget):
                 name = state["name"]
                 crop_name = name + self._suffix
                 if crop_name in self._viewer.layers:
+                    state["visible"] = self._viewer.layers[crop_name].visible
                     self._viewer.layers.remove(crop_name)
 
                 data = node.roi(data[node.time])
@@ -114,7 +115,6 @@ class GenericAnnotationWidget(GenericDataWidget):
                 )
                 state["scale"] = state["scale"][-data.ndim :]
                 state["name"] = crop_name
-                state["visible"] = True
 
                 # removing this matrices for now
                 state.pop("rotate")


### PR DESCRIPTION
The node layers' visibility is reset to True every time it is loaded. It affects user experience since the user has to toggle his preferred visibility every time.