### PR TITLE
Improve installation guide and env files for Napari/Qt and PlantSeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/instal
 Create a conda environment.
 
 ```bash
-conda create --name tracking python=3.10
+conda create --name tracking -c conda-forge python=3.10 pyqt
 ```
 
 And activate it.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -3,3 +3,6 @@ FAQ
 
 **Q: What is each configuration parameters for?**
     A: See the `configuration README <https://github.com/royerlab/ultrack/tree/main/ultrack/config>`_.
+
+**Q: What to do when Qt platform plugin cannot be initialized?**
+    A: The solution to try is to install `pyqt` using `conda` from the `-c conda-forge` channel.

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,7 @@ Therefore, conda environment files are provided, they can be installed using:
 ```
 conda env create -f <environment-file.yml>
 conda activate <your new env>
+pip install git+https://github.com/royerlab/ultrack
 ```
 
 The existing examples are:

--- a/examples/neuromast_plantseg/environment_cpu.yml
+++ b/examples/neuromast_plantseg/environment_cpu.yml
@@ -1,11 +1,10 @@
-name: ultrack-flow-field
+name: ultrack-plant-seg
 channels:
   - pytorch
   - gurobi
   - rapidsai
   - conda-forge
   - defaults
-  - lcerrone
 dependencies:
   - coin-or-cbc
   - cucim
@@ -13,10 +12,8 @@ dependencies:
   - cpuonly
   - gurobi
   - jupyter
-  - pip
-  - plantseg
   - pyqt
   - pytorch
-  - pip:
-    - napari==0.4.18
-    - napari-ome-zarr
+  - plant-seg
+  - napari
+  - napari-ome-zarr

--- a/examples/neuromast_plantseg/environment_gpu.yml
+++ b/examples/neuromast_plantseg/environment_gpu.yml
@@ -6,18 +6,15 @@ channels:
   - rapidsai
   - conda-forge
   - defaults
-  - lcerrone
 dependencies:
   - coin-or-cbc
   - cucim
   - cupy
   - gurobi
   - jupyter
-  - pip
   - pyqt
   - pytorch
   - pytorch-cuda
-  - plantseg
-  - pip:
-    - napari==0.4.18
-    - napari-ome-zarr
+  - plant-seg
+  - napari
+  - napari-ome-zarr

--- a/examples/neuromast_plantseg/environment_gpu.yml
+++ b/examples/neuromast_plantseg/environment_gpu.yml
@@ -14,7 +14,8 @@ dependencies:
   - jupyter
   - pyqt
   - pytorch
-  - pytorch-cuda
+  - pytorch-cuda=12.1
+  - cudnn
   - plant-seg
   - napari
   - napari-ome-zarr


### PR DESCRIPTION
Hi @JoOkuma, your software looks awesome! I am a maintainer of PlantSeg and @tischi is trying to use it for one of our project. I had a look at #84 and made a few fixes. It looks like contributions are welcomed, so I'll just make PR here:

- In the environment config in PlantSeg example, I changed the name and channel of PlantSeg, since we moved our software to `conda-forge` channel already. I also made all dependencies in these files pure conda-based, as they provides the same packages. Specifying a version for `pytorch-cuda` is recommended by PyTorch and cuCIM installation.
- In the main README and the Q&A in doc, I emphasis the need of installing `pyqt` via `-c conda-forge` prior the installation of `ultrack`, since Napari is a default dependency and it requires but doesn't come with Qt. Note that `pyqt` from `conda-forge` channel is the most robust installation from my experience and should guarantee the launch of Napari.

I tested the installation on EMBL cluster and my system to run PlantSeg Napari pipeline and Ultrack tracking on @tischi's dataset without a problem, so I believe it's ready to be merged. Please have a look and see if things need to be modified.