### PR TITLE
Skip CuPy v13.0.* due to broken `ElementwiseKernel` and other core kernels

### DIFF
--- a/examples/flow_field_3d/environment_gpu.yml
+++ b/examples/flow_field_3d/environment_gpu.yml
@@ -9,13 +9,13 @@ channels:
 dependencies:
   - coin-or-cbc
   - cucim
-  - cupy
+  - cupy!=13.0.*
   - gurobi
   - jupyter
+  - napari
   - pip
   - pyqt
   - pytorch
   - pytorch-cuda
   - pip:
-    - napari==0.4.18
     - traccuracy

--- a/examples/micro_sam/environment_gpu.yml
+++ b/examples/micro_sam/environment_gpu.yml
@@ -9,7 +9,7 @@ channels:
 dependencies:
   - coin-or-cbc
   - cucim
-  - cupy
+  - cupy!=13.0.*
   - gurobi
   - jupyter
   - pip

--- a/examples/multi_color_ensemble/environment_gpu.yml
+++ b/examples/multi_color_ensemble/environment_gpu.yml
@@ -8,7 +8,7 @@ dependencies:
   - cellpose
   - coin-or-cbc
   - cucim
-  - cupy
+  - cupy!=13.0.*
   - gurobi
   - jupyter
   - pip

--- a/examples/neuromast_plantseg/environment_gpu.yml
+++ b/examples/neuromast_plantseg/environment_gpu.yml
@@ -9,7 +9,7 @@ channels:
 dependencies:
   - coin-or-cbc
   - cucim
-  - cupy
+  - cupy!=13.0.*
   - gurobi
   - jupyter
   - pyqt

--- a/examples/stardist_2d/environment_gpu.yml
+++ b/examples/stardist_2d/environment_gpu.yml
@@ -10,7 +10,7 @@ dependencies:
   - conda-forge::cudatoolkit=11.2
   - conda-forge::cudnn=8.4.1
   - conda-forge::tensorflow-gpu=2.11.0
-  - conda-forge::cupy
+  - conda-forge::cupy!=13.0.*
   - coin-or-cbc
   - gurobi
   - jupyter

--- a/examples/zebrahub/environment_gpu.yml
+++ b/examples/zebrahub/environment_gpu.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   - coin-or-cbc
   - cucim
-  - cupy
+  - cupy!=13.0.*
   - gurobi
   - jupyter
   - pip


### PR DESCRIPTION
Without `!=13.0.*`, `timelapse_flow()` failed. It is promised to be fixed in `v13.1.0` so we avoid all `v13.0.*`. I tested tracking with flow on the flow field 3D env and believe other gpu env dependencies should also avoid this version. 

Related Issues:

- https://github.com/cupy/cupy/issues/8184#issuecomment-1944328942


