### PR TITLE
Bug fix and improvement in TrackMate export

### DIFF
--- a/ultrack/core/export/_test/test_trackmate.py
+++ b/ultrack/core/export/_test/test_trackmate.py
@@ -10,7 +10,11 @@ from ultrack.core.export.trackmate import tracks_layer_to_trackmate
 pytrackmate = pytest.importorskip("pytrackmate")
 
 
-def test_trackmate_writer(tmp_path: Path) -> None:
+def test_trackmate_export_spot_match(tmp_path: Path) -> None:
+    """Check if the spots (objects) match between the tracks and the exported trackmate xml file.
+
+    This test cannot check if the exported tracking is valid.
+    """
     tracks_outpath = tmp_path / "tracks.xml"
 
     tracks_df = pd.DataFrame(


### PR DESCRIPTION
Hey @JoOkuma,

@tischi and I encountered a small but critical and elusive bug, fixed by this PR.

![image](https://github.com/royerlab/ultrack/assets/17722010/ce28f01c-f937-4d89-ae6a-5a091822a84e)

_Fig. 1. TrackMate. Before: no tracks | After: tracks | After: details_

![image](https://github.com/royerlab/ultrack/assets/17722010/9cb7bd9f-b78e-4cdf-8d1b-4ac43156fd60)

_Fig. 2. Mastodon. After: tracks and details_

The current test for exporting tracks to TrackMate solely verifies the inclusion of all spots in the output, neglecting tracking semantics. In this PR, I choose not to implement an additional test that merely converts the XML back, since the essential validation comes from the actual opening and viewing of successful tracks. I revised the function's name, though I suspect it has not been used for a while.

### Before Fix

TrackMate launches with error:

```
Some errors occurred while reading file:

Unknown spot ID: 2000008
Could not find the detector element in file.
Could not find the tracker element in file.
Could not find the feature analyzer element.
Could not find the display-settings element. Returning user defaults.
```

Mastodon throws error only:

```
Exception in thread "Thread-8" java.lang.NullPointerException
	at org.mastodon.mamut.io.importer.trackmate.TrackMateImporter$Import.<init>(TrackMateImporter.java:429)
	at org.mastodon.mamut.io.importer.trackmate.TrackMateImporter.readModel(TrackMateImporter.java:236)
	at org.mastodon.mamut.launcher.MastodonLauncher.lambda$importMaMuT$18(MastodonLauncher.java:504)
	at java.lang.Thread.run(Thread.java:748)
```
