### PR TITLE
Add a Dependabot config to auto-update GitHub action versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Currently, deprecation warnings are being thrown due to actions using out-of-date Node versions ([recent example](https://github.com/royerlab/ultrack/actions/runs/9321760412)). Rather than submitting a PR to update them manually, this PR configures Dependabot to regularly submit PRs to update GitHub action versions as needed.

If this PR merges, you can expect Dependabot to immediately submit a PR to update actions to newer versions.