### PR TITLE
added database_name property to config.DataConfig

### DIFF
--- a/ultrack/config/dataconfig.py
+++ b/ultrack/config/dataconfig.py
@@ -27,7 +27,7 @@ class DataConfig(BaseModel):
     working_dir: Path = Path(".")
     """Working directory for auxiliary files (e.g. sqlite database, metadata)"""
 
-    database_name: str = "data.db"
+    database_file_name: str = "data.db"
     """Database name, used for sqlite databases, by default: `data.db`"""
 
     database: DatabaseChoices = "sqlite"

--- a/ultrack/config/dataconfig.py
+++ b/ultrack/config/dataconfig.py
@@ -81,7 +81,7 @@ class DataConfig(BaseModel):
     def database_path(self) -> str:
         """Returns database path given working directory and database type."""
         if self.database == DatabaseChoices.sqlite.value:
-            return f"sqlite:///{self.working_dir.absolute()}/{self.database_name}"
+            return f"sqlite:///{self.working_dir.absolute()}/{self.database_file_name}"
 
         elif self.database == DatabaseChoices.memory.value:
             return f"sqlite:///file:{self.in_memory_db_id}?mode=memory&cache=shared&uri=true"

--- a/ultrack/config/dataconfig.py
+++ b/ultrack/config/dataconfig.py
@@ -27,6 +27,9 @@ class DataConfig(BaseModel):
     working_dir: Path = Path(".")
     """Working directory for auxiliary files (e.g. sqlite database, metadata)"""
 
+    database_name: str = "data.db"
+    """Database name, used for sqlite databases, by default: `data.db`"""
+
     database: DatabaseChoices = "sqlite"
     """``SPECIAL``: Database type ``sqlite`` and ``postgresql`` supported"""
 
@@ -78,7 +81,7 @@ class DataConfig(BaseModel):
     def database_path(self) -> str:
         """Returns database path given working directory and database type."""
         if self.database == DatabaseChoices.sqlite.value:
-            return f"sqlite:///{self.working_dir.absolute()}/data.db"
+            return f"sqlite:///{self.working_dir.absolute()}/{self.database_name}"
 
         elif self.database == DatabaseChoices.memory.value:
             return f"sqlite:///file:{self.in_memory_db_id}?mode=memory&cache=shared&uri=true"


### PR DESCRIPTION
In case a working directory has multiple database files, this property (which defaults to `"data.db"`) allows one to specify which database to load from or save into