### PR TITLE
Flow and CTC conversion fix

### DIFF
--- a/ultrack/core/export/ctc.py
+++ b/ultrack/core/export/ctc.py
@@ -371,8 +371,8 @@ def to_ctc(
         )
 
     df["track_id"], fw, _ = relabel_sequential(df["track_id"].values)
-    fw[NO_PARENT] = NO_PARENT
-    df["parent_track_id"] = fw[df["parent_track_id"].values]
+    mask = df["parent_track_id"] != -1
+    df.loc[mask, "parent_track_id"] = fw[df.loc[mask, "parent_track_id"].values]
 
     # convert to CTC format and write output
     tracks_df = ctc_compress_forest(df)

--- a/ultrack/core/export/ctc.py
+++ b/ultrack/core/export/ctc.py
@@ -371,7 +371,7 @@ def to_ctc(
         )
 
     df["track_id"], fw, _ = relabel_sequential(df["track_id"].values)
-    mask = df["parent_track_id"] != -1
+    mask = df["parent_track_id"] != NO_PARENT
     df.loc[mask, "parent_track_id"] = fw[df.loc[mask, "parent_track_id"].values]
 
     # convert to CTC format and write output

--- a/ultrack/core/main.py
+++ b/ultrack/core/main.py
@@ -96,8 +96,8 @@ def track(
         )
 
     if overwrite in ("all", "links", "none"):
-        link(config, images=images, scale=scale)
         if vector_field is not None:
             add_flow(config, vector_field)
+        link(config, images=images, scale=scale)
 
     solve(config)


### PR DESCRIPTION
- In the track function, link() is called before add_flow(), such that the flow is never actually used.
- In the to_ctc function, the forward_map returned by relabel_sequential is modified like this: 'fw[-1] = -1', because the parent_id -1 (no parent) should be mapped on itself. However, instead of adding a map from -1 to -1, this modifies the last value in the map and -1 is mapped to the default of 0. As the CTC format expects 0 for no parent, this is not an issue, but through the modification of the map, the parent of the last tracklet is set to -1, effectively cutting it off.