### PR TITLE
Fix widget compatibility with multi-scale napari image layers

### DIFF
--- a/ultrack/cli/export.py
+++ b/ultrack/cli/export.py
@@ -25,6 +25,7 @@ from ultrack.core.export import (
 from ultrack.core.solve.sqltracking import SQLTracking
 from ultrack.imgproc.measure import tracks_properties
 from ultrack.utils.data import validate_and_overwrite_path
+from ultrack.utils.napari import get_layer_data
 
 
 @click.command("ctc")
@@ -156,7 +157,7 @@ def zarr_napari_cli(
             _initialize_plugins()
             viewer = ViewerModel()
             image = [
-                layer.data[0] if layer.multiscale else layer.data
+                get_layer_data(layer)
                 for layer in viewer.open(image_path, plugin=reader_plugin)
             ]
             del viewer

--- a/ultrack/cli/flow.py
+++ b/ultrack/cli/flow.py
@@ -13,6 +13,7 @@ from ultrack.cli.utils import (
 )
 from ultrack.config import MainConfig
 from ultrack.imgproc.flow import add_flow
+from ultrack.utils.napari import get_layer_data
 
 
 @click.command("add_flow")
@@ -32,7 +33,7 @@ def add_flow_cli(
     viewer = ViewerModel()
 
     vector_field = [
-        layer.data[0] if layer.multiscale else layer.data
+        get_layer_data(layer)
         for layer in viewer.open(paths, channel_axis=channel_axis, plugin=reader_plugin)
     ]
     del viewer

--- a/ultrack/cli/link.py
+++ b/ultrack/cli/link.py
@@ -15,6 +15,7 @@ from ultrack.cli.utils import (
     paths_argument,
 )
 from ultrack.config import MainConfig
+from ultrack.utils.napari import get_layer_data
 
 
 @click.command("link")
@@ -48,7 +49,7 @@ def link_cli(
             kwargs["channel_axis"] = channel_axis
 
         images = [
-            layer.data[0] if layer.multiscale else layer.data
+            get_layer_data(layer)
             for layer in viewer.open(paths, **kwargs, plugin=reader_plugin)
         ]
         del viewer

--- a/ultrack/cli/match_gt.py
+++ b/ultrack/cli/match_gt.py
@@ -9,7 +9,6 @@ from napari.plugins import _initialize_plugins
 from napari.viewer import ViewerModel
 from rich.logging import RichHandler
 
-from ultrack.cli.segment import _get_layer_data
 from ultrack.cli.utils import (
     batch_index_option,
     config_option,
@@ -21,6 +20,7 @@ from ultrack.cli.utils import (
 from ultrack.config import MainConfig
 from ultrack.core.match_gt import match_to_ground_truth
 from ultrack.ml.classification import fit_links_prob, fit_nodes_prob
+from ultrack.utils.napari import get_layer_data
 
 LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.INFO)
@@ -134,7 +134,7 @@ def match_gt_cli(
         else:
             ground_truth_layer = viewer.layers[0].name
 
-    gt = _get_layer_data(viewer, ground_truth_layer)
+    gt = get_layer_data(viewer.layers[ground_truth_layer])
 
     # Match ground-truth to database
     gt_df, new_config = match_to_ground_truth(

--- a/ultrack/cli/segment.py
+++ b/ultrack/cli/segment.py
@@ -5,7 +5,6 @@ import click
 import dask.array as da
 from napari.plugins import _initialize_plugins
 from napari.viewer import ViewerModel
-from numpy.typing import ArrayLike
 
 from ultrack import segment
 from ultrack.cli.utils import (
@@ -16,15 +15,7 @@ from ultrack.cli.utils import (
     paths_argument,
 )
 from ultrack.config import MainConfig
-
-
-def _get_layer_data(viewer: ViewerModel, key: str) -> ArrayLike:
-    """Get layer data from napari viewer."""
-    layer = viewer.layers[key]
-    if layer.multiscale:
-        return layer.data[0]
-    else:
-        return layer.data
+from ultrack.utils.napari import get_layer_data
 
 
 @click.command("segment")
@@ -87,8 +78,8 @@ def segmentation_cli(
     viewer = ViewerModel()
     viewer.open(path=paths, plugin=reader_plugin)
 
-    foreground = _get_layer_data(viewer, foreground_layer)
-    edge = _get_layer_data(viewer, contours_layer)
+    foreground = get_layer_data(viewer.layers[foreground_layer])
+    edge = get_layer_data(viewer.layers[contours_layer])
 
     if len(images_layer) == 0:
         images = None
@@ -102,10 +93,10 @@ def segmentation_cli(
             )
 
         if len(images_layer) == 1:
-            images = _get_layer_data(viewer, images_layer[0])
+            images = get_layer_data(viewer.layers[images_layer[0]])
         else:
             images = da.stack(
-                [_get_layer_data(viewer, key) for key in images_layer], axis=-1
+                [get_layer_data(viewer.layers[key]) for key in images_layer], axis=-1
             )
 
     if batch_index is None or batch_index == 0:

--- a/ultrack/utils/napari.py
+++ b/ultrack/utils/napari.py
@@ -1,0 +1,22 @@
+from napari.layers import Layer
+from napari.types import ArrayLike
+
+
+def get_layer_data(layer: Layer) -> ArrayLike:
+    """Return the array data from a napari layer.
+
+    For multi-scale layers, returns the highest-resolution level (index 0).
+
+    Parameters
+    ----------
+    layer : Layer
+        A napari layer, possibly multi-scale.
+
+    Returns
+    -------
+    ArrayLike
+        The underlying array data.
+    """
+    if layer.multiscale:
+        return layer.data[0]
+    return layer.data

--- a/ultrack/widgets/ultrackwidget/_test/test_ultrack_widget.py
+++ b/ultrack/widgets/ultrackwidget/_test/test_ultrack_widget.py
@@ -1,10 +1,11 @@
 import time
 from pathlib import Path
-from typing import Callable, List
+from typing import Callable, List, Tuple
 
 import napari
 import numpy as np
 import pytest
+import zarr
 
 from ultrack.config import MainConfig
 from ultrack.widgets.ultrackwidget import UltrackWidget
@@ -95,6 +96,66 @@ def test_ultrack_widget(
     ####################################################################################
     # CHECK IF THE WIDGET CAN RUN
     ####################################################################################
+    widget._bt_run.clicked.emit()
+
+    time.sleep(1)
+    while widget._current_worker is not None and widget._current_worker.is_running:
+        time.sleep(0.5)
+
+
+@pytest.mark.parametrize(
+    "workflow",
+    [
+        WorkflowChoice.AUTO_DETECT,
+        WorkflowChoice.AUTO_FROM_LABELS,
+        WorkflowChoice.MANUAL,
+    ],
+)
+def test_ultrack_widget_multiscale(
+    make_napari_viewer: Callable[[], napari.Viewer],
+    timelapse_mock_data: Tuple[zarr.Array, zarr.Array, zarr.Array],
+    workflow: WorkflowChoice,
+    tmp_path: Path,
+) -> None:
+    """Regression test: widget must accept multi-scale napari Image layers."""
+    foreground, contours, labels = timelapse_mock_data
+
+    viewer = make_napari_viewer()
+    widget = UltrackWidget(viewer)
+
+    config = MainConfig()
+    config.data_config.working_dir = tmp_path
+    widget._data_forms.load_config(config)
+
+    # Build multi-scale pyramids: two levels (full res + half res)
+    fg_arr = np.asarray(foreground, dtype=float)
+    ct_arr = np.asarray(contours, dtype=float)
+    lb_arr = np.asarray(labels)
+
+    multiscale_fg = [fg_arr, fg_arr[:, ::2, ::2]]
+    multiscale_ct = [ct_arr, ct_arr[:, ::2, ::2]]
+    multiscale_lb = [lb_arr, lb_arr[:, ::2, ::2]]
+
+    ms_detection = viewer.add_image(multiscale_fg, name="ms_detection", multiscale=True)
+    ms_contours = viewer.add_image(multiscale_ct, name="ms_contours", multiscale=True)
+    ms_labels = viewer.add_image(multiscale_lb, name="ms_labels", multiscale=True)
+
+    workflow_idx = widget._cb_workflow.findData(workflow)
+    widget._cb_workflow.setCurrentIndex(workflow_idx)
+    widget._cb_workflow.currentIndexChanged.emit(workflow_idx)
+
+    layers = viewer.layers
+    for cb in widget._cb_images.values():
+        cb.choices = layers
+
+    if workflow == WorkflowChoice.AUTO_DETECT:
+        widget._cb_images[UltrackInput.IMAGE].value = ms_detection
+    elif workflow == WorkflowChoice.AUTO_FROM_LABELS:
+        widget._cb_images[UltrackInput.LABELS].value = ms_labels
+    elif workflow == WorkflowChoice.MANUAL:
+        widget._cb_images[UltrackInput.DETECTION].value = ms_detection
+        widget._cb_images[UltrackInput.CONTOURS].value = ms_contours
+
     widget._bt_run.clicked.emit()
 
     time.sleep(1)

--- a/ultrack/widgets/ultrackwidget/utils.py
+++ b/ultrack/widgets/ultrackwidget/utils.py
@@ -1,8 +1,31 @@
 from enum import Enum
 
+from napari.layers import Layer
+from napari.types import ArrayLike
+
 
 class UltrackInput(Enum):
     IMAGE = "image"
     CONTOURS = "contours"
     DETECTION = "detection"
     LABELS = "labels"
+
+
+def get_layer_data(layer: Layer) -> ArrayLike:
+    """Return the array data from a napari layer.
+
+    For multi-scale layers, returns the highest-resolution level (index 0).
+
+    Parameters
+    ----------
+    layer : Layer
+        A napari layer, possibly multi-scale.
+
+    Returns
+    -------
+    ArrayLike
+        The underlying array data.
+    """
+    if getattr(layer, "multiscale", False):
+        return layer.data[0]
+    return layer.data

--- a/ultrack/widgets/ultrackwidget/utils.py
+++ b/ultrack/widgets/ultrackwidget/utils.py
@@ -1,7 +1,6 @@
 from enum import Enum
 
-from napari.layers import Layer
-from napari.types import ArrayLike
+from ultrack.utils.napari import get_layer_data  # noqa: F401
 
 
 class UltrackInput(Enum):
@@ -9,23 +8,3 @@ class UltrackInput(Enum):
     CONTOURS = "contours"
     DETECTION = "detection"
     LABELS = "labels"
-
-
-def get_layer_data(layer: Layer) -> ArrayLike:
-    """Return the array data from a napari layer.
-
-    For multi-scale layers, returns the highest-resolution level (index 0).
-
-    Parameters
-    ----------
-    layer : Layer
-        A napari layer, possibly multi-scale.
-
-    Returns
-    -------
-    ArrayLike
-        The underlying array data.
-    """
-    if getattr(layer, "multiscale", False):
-        return layer.data[0]
-    return layer.data

--- a/ultrack/widgets/ultrackwidget/utils.py
+++ b/ultrack/widgets/ultrackwidget/utils.py
@@ -1,7 +1,5 @@
 from enum import Enum
 
-from ultrack.utils.napari import get_layer_data  # noqa: F401
-
 
 class UltrackInput(Enum):
     IMAGE = "image"

--- a/ultrack/widgets/ultrackwidget/workflows.py
+++ b/ultrack/widgets/ultrackwidget/workflows.py
@@ -20,7 +20,7 @@ from ultrack.tracks import tracks_df_movement
 from ultrack.utils import labels_to_contours
 from ultrack.utils.array import array_apply, create_zarr
 from ultrack.utils.cuda import on_gpu
-from ultrack.widgets.ultrackwidget.utils import UltrackInput
+from ultrack.widgets.ultrackwidget.utils import UltrackInput, get_layer_data
 
 LOGGER = logging.getLogger(__name__)
 
@@ -188,8 +188,8 @@ class UltrackWorkflow:
                         scale = labels.scale
 
                     detection, contours = self._run_preprocessing(
-                        image=image.data if image is not None else None,
-                        labels=labels.data if labels is not None else None,
+                        image=get_layer_data(image) if image is not None else None,
+                        labels=get_layer_data(labels) if labels is not None else None,
                         choice=workflow_choice,
                         **additional_options,
                     )
@@ -351,14 +351,15 @@ class UltrackWorkflow:
                 flow_kwargs = additional_options["flow_kwargs"]
                 if flow_kwargs["__enable__"]:
                     del flow_kwargs["__enable__"]
+                    image_data = get_layer_data(image)
                     flow_field = timelapse_flow(
-                        image.data,
+                        image_data,
                         store_or_path=None,
                         **flow_kwargs,
                     )
                     flow_kwargs["__enable__"] = True
 
-                    shape = list(image.data.shape)
+                    shape = list(image_data.shape)
                     if flow_kwargs["channel_axis"]:
                         shape.pop(flow_kwargs["channel_axis"] + 1)
 
@@ -489,8 +490,8 @@ class UltrackWorkflow:
             The contours napari layer.
         """
         segment(
-            detection=detection.data,
-            edge=contours.data,
+            detection=get_layer_data(detection),
+            edge=get_layer_data(contours),
             config=self.config,
             overwrite=True,
         )

--- a/ultrack/widgets/ultrackwidget/workflows.py
+++ b/ultrack/widgets/ultrackwidget/workflows.py
@@ -20,7 +20,8 @@ from ultrack.tracks import tracks_df_movement
 from ultrack.utils import labels_to_contours
 from ultrack.utils.array import array_apply, create_zarr
 from ultrack.utils.cuda import on_gpu
-from ultrack.widgets.ultrackwidget.utils import UltrackInput, get_layer_data
+from ultrack.utils.napari import get_layer_data
+from ultrack.widgets.ultrackwidget.utils import UltrackInput
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Problem

When a napari `Image` layer is multi-scale (e.g. loaded from a zarr pyramid or created with `viewer.add_image(..., multiscale=True)`), its `.data` attribute is a `MultiScaleData` object — a list of arrays at progressively lower resolutions — rather than a single array.

The widget's workflow code passed `layer.data` directly to processing functions and called `.shape` on it, which raised:

```
TypeError: list indices must be integers or slices, not tuple
```

This affected all three workflow modes (AUTO_DETECT, AUTO_FROM_LABELS, MANUAL).

## Fix

Added `get_layer_data(layer)` helper in `utils.py` that returns `layer.data[0]` (the highest-resolution level) when a layer is multi-scale, and `layer.data` otherwise.

Applied it in `workflows.py` at every point where user-supplied layer data is consumed:
- preprocessing step (image → auto-detect, labels → auto-from-labels)  
- segmentation step (detection and contours in manual mode)
- optical flow computation

## Tests

Added `test_ultrack_widget_multiscale` parametrized over all three workflow choices, each using a two-level image pyramid built from the existing mock data fixtures. The tests confirmed the failure before the fix and pass after.