### PR TITLE
fix: guard against empty nodes in compute_spatial_neighbors (issue #274)

### DIFF
--- a/ultrack/core/linking/processing.py
+++ b/ultrack/core/linking/processing.py
@@ -186,6 +186,9 @@ def compute_spatial_neighbors(
     source_pos = np.asarray([n.centroid for n in source_nodes])
     target_pos = np.asarray([n.centroid for n in target_nodes], dtype=np.float32)
 
+    if source_pos.ndim < 2 or target_pos.ndim < 2:
+        return
+
     n_dim = target_pos.shape[1]
     target_shift = target_shift[:, -n_dim:]  # matching positions dimensions
     target_pos += target_shift


### PR DESCRIPTION
## Summary

Fixes `IndexError: tuple index out of range` in `compute_spatial_neighbors` when any timepoint has zero detected cells.

## Root cause

When `target_nodes` or `source_nodes` is empty, `np.asarray([])` returns a 1D array with `shape=(0,)`. Accessing `target_pos.shape[1]` then raises `IndexError` since there is no second dimension.

## Fix

Added a guard before accessing `shape[1]`:

```python
if source_pos.ndim < 2 or target_pos.ndim < 2:
    return
```

Skipping linking for timepoint pairs where either side has no cells is the correct behavior — there is nothing to link.

## Testing

Verified the fix against the exact stack trace from issue #274.

Fixes royerlab/ultrack#274