### PR TITLE
fix(cuda): define xp when cupy is installed but CUDA is unavailable

### DIFF
--- a/ultrack/utils/cuda.py
+++ b/ultrack/utils/cuda.py
@@ -19,6 +19,7 @@ try:
 
     if not cp.cuda.is_available():
         cp = None
+        xp = np
         LOG.info("cupy found but cuda is not available.")
     else:
         from cupy.cuda.memory import malloc_managed


### PR DESCRIPTION
Closes #277

When cupy is installed but `cp.cuda.is_available()` returns `False` (e.g. a CPU-only HPC node with cupy in the shared env), `xp` was never assigned, so `from ultrack.utils.cuda import xp` raised `ImportError` and broke any `ultrack` import.

Mirror the cupy-not-installed branch and set `xp = np` here too.

Reproduced the failure locally with a fake `cupy` module whose `cuda.is_available()` returns `False`; with the patch, `xp is np` and the downstream import in `ultrack.utils.edge` succeeds.